### PR TITLE
Fix error in ProofReplyEvent

### DIFF
--- a/requests-responses.md
+++ b/requests-responses.md
@@ -127,7 +127,7 @@ type TonProofItemReplySuccess = {
 }
 
 type TonProofItemReplyError = {
-  name: "ton_addr";
+  name: "ton_proof";
   error: {
       code: ConnectItemErrorCode;
       message?: string;


### PR DESCRIPTION
According to [TonKeeper](https://github.com/tonkeeper/android/blob/92c70ea742c6ddb31224c3c716e852324a8a3497/apps/wallet/instance/app/src/main/java/com/tonapps/tonkeeper/manager/tonconnect/bridge/JsonBuilder.kt#L112-L124) android source code it will be "ton_proof", not "ton_addr". Besides it's obvious error