### PR TITLE
Add extra information about `wallet` info field

### DIFF
--- a/bridge.md
+++ b/bridge.md
@@ -135,12 +135,10 @@ JS bridge runs on the same device as the wallet and the app, so communication is
 
 The app works directly with plaintext requests and responses, without session keys and encryption.
 
-`walletInfo` field must be defined for Ton Connect be able connecting with your wallet.
-
 ```tsx
 interface TonConnectBridge {
     deviceInfo: DeviceInfo; // see Requests/Responses spec
-    walletInfo?: WalletInfo;
+    walletInfo: WalletInfo;
     protocolVersion: number; // max supported Ton Connect version (e.g. 2)
     isWalletBrowser: boolean; // if the page is opened into wallet's browser
     connect(protocolVersion: number, message: ConnectRequest): Promise<ConnectEvent>;


### PR DESCRIPTION
According to the [sdk code](https://github.com/ton-connect/sdk/blob/1e3d04270973ddef284584a457d27a340f75565c/packages/sdk/src/provider/injected/models/injected-wallet-api.ts#L32-L48). `walletInfo` must be defined to pass TonConnect sdk JS bridge checking